### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 # Based on https://github.com/ionic-team/capacitor-plugins/blob/main/.github/workflows/ci.yml
 name: "CI"
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/independo-gmbh/capacitor-voice-recorder/security/code-scanning/5](https://github.com/independo-gmbh/capacitor-voice-recorder/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the root of the workflow or to each job that does not already have explicit permissions. The `permissions` block should specify the least privileges required for the job to function correctly. For example:
- Jobs that only need to read repository contents should have `contents: read`.
- Jobs that require write access to specific resources (e.g., issues or pull requests) should explicitly define those permissions.

In this case, we will add a `permissions` block at the root level of the workflow to apply to all jobs that do not have their own `permissions` block. This ensures consistency and reduces redundancy.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
